### PR TITLE
Run Tests on all branches; Update Github Action Dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,24 @@ jobs:
       - name: Check if Prettier could format code
         run: npx prettier --check --no-config .
 
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install modules
+        run: npm ci
+      - name: Launch Python Server
+        run: python3 -m http.server &
+      - name: Run Jest Tests
+        run: BASE=http://127.0.0.1:8000 npm test
+
   jsdocs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,18 +9,26 @@ jobs:
   lint_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cahce: 'npm'
       - name: Install modules
-        run: yarn
+        run: npm ci
       - name: Run ESLint
         run: npm run lint
 
   format_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cahce: 'npm'
       - name: Install modules
-        run: yarn
+        run: npm ci
       - name: Check if Prettier could format code
         run: npx prettier --check --no-config .
 
@@ -28,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build JSDOCS
         uses: andstor/jsdoc-action@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cahce: 'npm'
+          cache: "npm"
       - name: Install modules
         run: npm ci
       - name: Run ESLint
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cahce: 'npm'
+          cache: "npm"
       - name: Install modules
         run: npm ci
       - name: Check if Prettier could format code


### PR DESCRIPTION
These commits fixes the issue where Jest tests only run on the live site (meaning no automated testing for other branches and no possibility of catching problems before changes are pushed to users).

In addition, caching of the npm dependencies has been implemented for the Github action runners.

Finally I also updated `actions/checkout` to use version 4.