### PR TITLE
"open cookie button fixed"

### DIFF
--- a/source/fortune-cookie/style.css
+++ b/source/fortune-cookie/style.css
@@ -168,10 +168,9 @@ li.audio-dropdown {
 }
 
 .button {
-  position: relative;
+  position: absolute;
+  top: 100%;
   margin-top: 20px;
-  width: 200px;
-  text-align: center;
 }
 .button:disabled {
   opacity: 0;
@@ -326,27 +325,4 @@ aside {
 }
 #cancel-animation-btn:hover {
   text-decoration: underline;
-}
-@media screen and (orientation: landscape) {
-  header {
-    margin-top: 0px;
-  }
-  footer {
-    margin-bottom: 5px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-  }
-  .fortune-cookie {
-    width: 200px;
-    height: 200px;
-    margin-top: 60px;
-  }
-  .button {
-    margin-top: 0px;
-  }
-  .button:disabled {
-    position: absolute;
-  }
 }


### PR DESCRIPTION
Fix the open cookie button.
The open cookie button was not visible on an iPhone SE3 if it's in the landscape. After fixing, it now works on any device that is in the landscape.
