### PR TITLE
"Bug/opencookiebutton"

### DIFF
--- a/__tests__/cookie-cancel.test.js
+++ b/__tests__/cookie-cancel.test.js
@@ -130,7 +130,7 @@ describe("Basic user flow for Website", () => {
       );
     });
     expect(elementHasClass).toBe(true);
-  }, 50000);
+  }, 5000);
 
   // Check to make sure that cancel button cancel button works when clicked after cookie button is clicked
   it("Make sure cancel button works when clicked after cookie button is clicked", async () => {
@@ -192,5 +192,67 @@ describe("Basic user flow for Website", () => {
       );
     });
     expect(elementHasClass).toBe(false);
-  }, 50000);
+  }, 5000);
+
+  // Check to make sure that cancel button cancel button works when clicked after reset button is clicked
+  it("Make sure cancel button works when clicked after reset button is clicked", async () => {
+    const resetButton = await page.$("#reset-button");
+    await resetButton.click();
+
+    // Skip animation button should appear
+    await page.waitForSelector("#cancel-animation-btn", { visible: true });
+    const cancelButton = await page.$("#cancel-animation-btn");
+    await cancelButton.click();
+    // Skip animation button should disappear
+    await page.waitForSelector("#cancel-animation-btn", { visible: false });
+
+    // Fortune button should be enabled
+    await page.waitForFunction(() => {
+      const fortuneButton = document.querySelector("#fortune-button");
+      return fortuneButton && fortuneButton.disabled === false;
+    });
+
+    // Check that fortune button is now enabled
+    let fortuneButtonDisabled;
+    const fortuneButton = await page.$("#fortune-button");
+    let booleanValue = await fortuneButton.getProperty("disabled");
+    fortuneButtonDisabled = await booleanValue.jsonValue();
+    expect(fortuneButtonDisabled).toBe(false);
+
+    // Cookie button should be enabled as well
+    let cookieButtonDisabled;
+    const cookieButton = await page.$("#cookie-button");
+    booleanValue = await cookieButton.getProperty("disabled");
+    cookieButtonDisabled = await booleanValue.jsonValue();
+    expect(cookieButtonDisabled).toBe(false);
+
+    // Reset button should now be disabled
+    let resetButtonDisabled;
+    booleanValue = await resetButton.getProperty("disabled");
+    resetButtonDisabled = await booleanValue.jsonValue();
+    expect(resetButtonDisabled).toBe(true);
+
+    // fortune paper should not be visible
+    let elementHasClass = await page.evaluate(() => {
+      const fortunePaper = document.querySelector("#fortune-paper");
+      return fortunePaper.classList.contains("reveal");
+    });
+    expect(elementHasClass).toBe(false);
+
+    // cancel button should not have animating class
+    elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains("animating");
+    });
+    expect(elementHasClass).toBe(false);
+
+    // cancel button should have cancel-animation-wrapper class
+    elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains(
+        "animating-new-cookie"
+      );
+    });
+    expect(elementHasClass).toBe(true);
+  }, 5000);
 });

--- a/__tests__/cookie.test.js
+++ b/__tests__/cookie.test.js
@@ -151,6 +151,101 @@ describe("Basic user flow for Website", () => {
     expect(elementHasClass).toBe(false);
   }, 5000);
 
+  // Check to make sure that reset button gets disabled when the reset button is clicked
+  it("Make sure after reset button is clicked, reset button is disabled", async () => {
+    // Click reset button
+    let resetButtonDisabled;
+    const resetButton = await page.$("#reset-button");
+    await resetButton.click();
+
+    // Check that reset button is now disabled
+    let booleanValue = await resetButton.getProperty("disabled");
+    resetButtonDisabled = await booleanValue.jsonValue();
+    expect(resetButtonDisabled).toBe(true);
+  }, 5000);
+
+  // Check to make sure that cancel button becomes visible and has correct classes after reset button is clicked
+  it("Make sure cancel button is visible and has correct classes when reset button is clicked", async () => {
+    // Only get past here if cancel button is visible
+    await page.waitForSelector("#cancel-animation-btn", { visible: true });
+
+    // cancel button should have animating class
+    let elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains("animating");
+    });
+    expect(elementHasClass).toBe(true);
+
+    // cancel button should have cancel-animation-wrapper class
+    elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains(
+        "animating-new-cookie"
+      );
+    });
+    expect(elementHasClass).toBe(true);
+  }, 5000);
+
+  // Now that reset button has been clicked, check that the fortune button is enabled
+  it("Make sure that after the reset button is clicked, the fortune button is reenabled", async () => {
+    /**
+     * The waitForFunction() waits for the provided function to return true, indicating that the button element with the ID 'fortune-button'
+     * has its disabled attribute set to false. If the button's disabled value becomes false within the specified timeout, the test will pass.
+     */
+    await page.waitForFunction(() => {
+      const fortuneButton = document.querySelector("#fortune-button");
+      return fortuneButton && fortuneButton.disabled === false;
+    });
+
+    // Check that fortune button is now enabled
+    let fortuneButtonDisabled;
+    const fortuneButton = await page.$("#fortune-button");
+    let booleanValue = await fortuneButton.getProperty("disabled");
+    fortuneButtonDisabled = await booleanValue.jsonValue();
+    expect(fortuneButtonDisabled).toBe(false);
+  }, 10000);
+
+  // Now that reset button has been clicked, check that the cookie button is enabled
+  it("Make sure after reset button is clicked, the cookie button is reenabled", async () => {
+    /**
+     * The waitForFunction() waits for the provided function to return true, indicating that the button element with the ID 'cookie-button'
+     * has its disabled attribute set to false. If the button's disabled value becomes false within the specified timeout, the test will pass.
+     */
+    await page.waitForFunction(() => {
+      const cookieButton = document.querySelector("#cookie-button");
+      return cookieButton && cookieButton.disabled === false;
+    });
+
+    // Check that cookie button is now enabled
+    let cookieButtonDisabled;
+    const cookieButton = await page.$("#cookie-button");
+    let booleanValue = await cookieButton.getProperty("disabled");
+    cookieButtonDisabled = await booleanValue.jsonValue();
+    expect(cookieButtonDisabled).toBe(false);
+  }, 5000);
+
+  // Check to make sure that cancel button becomes not visible and has correct classes after fortune/cookie button are enabled
+  it("Make sure cancel button is not visible and has correct classes after fortune/cookie button are enabled", async () => {
+    // Only get past here if cancel button is not visible
+    await page.waitForSelector("#cancel-animation-btn", { visible: false });
+
+    // cancel button should not have animating class
+    let elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains("animating");
+    });
+    expect(elementHasClass).toBe(false);
+
+    // cancel button should have cancel-animation-wrapper class
+    elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains(
+        "animating-new-cookie"
+      );
+    });
+    expect(elementHasClass).toBe(true);
+  }, 5000);
+
   // Now test all buttons when the cookie button is clicked
 
   // Check to make sure that cookie button disables when it is clicked
@@ -174,6 +269,28 @@ describe("Basic user flow for Website", () => {
     expect(fortuneButtonDisabled).toBe(true);
   }, 5000);
 
+  // Check to make sure that cancel button becomes visible and has correct classes after cookie button is clicked
+  it("Make sure cancel button is visible and has correct classes when cookie button is clicked", async () => {
+    // Only get past here if cancel button is visible
+    await page.waitForSelector("#cancel-animation-btn", { visible: true });
+
+    // cancel button should have animating class
+    let elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains("animating");
+    });
+    expect(elementHasClass).toBe(true);
+
+    // cancel button should not have cancel-animation-wrapper class
+    elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains(
+        "animating-new-cookie"
+      );
+    });
+    expect(elementHasClass).toBe(false);
+  }, 5000);
+
   // Check to make sure that reset button is enabled when after cookie button is clicked
   it("Make sure reset button is enabled after cookie button is clicked", async () => {
     /**
@@ -192,6 +309,101 @@ describe("Basic user flow for Website", () => {
     resetButtonDisabled = await booleanValue.jsonValue();
     expect(resetButtonDisabled).toBe(false);
   }, 25000);
+
+  // Check to make sure that reset button gets disabled when the reset button is clicked
+  it("Make sure after reset button is clicked, reset button is disabled", async () => {
+    // Click reset button
+    let resetButtonDisabled;
+    const resetButton = await page.$("#reset-button");
+    await resetButton.click();
+
+    // Check that reset button is now disabled
+    let booleanValue = await resetButton.getProperty("disabled");
+    resetButtonDisabled = await booleanValue.jsonValue();
+    expect(resetButtonDisabled).toBe(true);
+  }, 5000);
+
+  // Check to make sure that cancel button becomes visible and has correct classes after reset button is clicked
+  it("Make sure cancel button is visible and has correct classes when reset button is clicked", async () => {
+    // Only get past here if cancel button is visible
+    await page.waitForSelector("#cancel-animation-btn", { visible: true });
+
+    // cancel button should have animating class
+    let elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains("animating");
+    });
+    expect(elementHasClass).toBe(true);
+
+    // cancel button should have cancel-animation-wrapper class
+    elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains(
+        "animating-new-cookie"
+      );
+    });
+    expect(elementHasClass).toBe(true);
+  }, 5000);
+
+  // Now that reset button has been clicked, check that the fortune button is enabled
+  it("Make sure that after the reset button is clicked, the fortune button is reenabled", async () => {
+    /**
+     * The waitForFunction() waits for the provided function to return true, indicating that the button element with the ID 'fortune-button'
+     * has its disabled attribute set to false. If the button's disabled value becomes false within the specified timeout, the test will pass.
+     */
+    await page.waitForFunction(() => {
+      const fortuneButton = document.querySelector("#fortune-button");
+      return fortuneButton && fortuneButton.disabled === false;
+    });
+
+    // Check that fortune button is now enabled
+    let fortuneButtonDisabled;
+    const fortuneButton = await page.$("#fortune-button");
+    let booleanValue = await fortuneButton.getProperty("disabled");
+    fortuneButtonDisabled = await booleanValue.jsonValue();
+    expect(fortuneButtonDisabled).toBe(false);
+  }, 10000);
+
+  // Now that reset button has been clicked, check that the cookie button is enabled
+  it("Make sure after reset button is clicked, the cookie button is reenabled", async () => {
+    /**
+     * The waitForFunction() waits for the provided function to return true, indicating that the button element with the ID 'cookie-button'
+     * has its disabled attribute set to false. If the button's disabled value becomes false within the specified timeout, the test will pass.
+     */
+    await page.waitForFunction(() => {
+      const cookieButton = document.querySelector("#cookie-button");
+      return cookieButton && cookieButton.disabled === false;
+    });
+
+    // Check that cookie button is now enabled
+    let cookieButtonDisabled;
+    const cookieButton = await page.$("#cookie-button");
+    let booleanValue = await cookieButton.getProperty("disabled");
+    cookieButtonDisabled = await booleanValue.jsonValue();
+    expect(cookieButtonDisabled).toBe(false);
+  }, 5000);
+
+  // Check to make sure that cancel button is not visible and has correct classes after fortune/cookie button are enabled
+  it("Make sure cancel button is not visible and has correct classes after fortune/cookie button are enabled", async () => {
+    // Only get past here if cancel button is not visible
+    await page.waitForSelector("#cancel-animation-btn", { visible: false });
+
+    // cancel button should not have animating class
+    let elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains("animating");
+    });
+    expect(elementHasClass).toBe(false);
+
+    // cancel button should have cancel-animation-wrapper class
+    elementHasClass = await page.evaluate(() => {
+      const cancelButton = document.querySelector("#cancel-animation-btn");
+      return cancelButton.parentElement.classList.contains(
+        "animating-new-cookie"
+      );
+    });
+    expect(elementHasClass).toBe(true);
+  }, 5000);
 
   //Check to make sure that the speech synthesis is being populated, the correct voices are called by the function
   it("Make sure that the speech synthesis options are working correctly", async () => {

--- a/source/fortune-cookie/style.css
+++ b/source/fortune-cookie/style.css
@@ -3,7 +3,7 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  overflow: auto;
+  overflow: hidden;
 }
 
 /* background image settings */
@@ -127,7 +127,7 @@ li.audio-dropdown {
 }
 
 .content {
-  position: relative;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Fix the open cookie button.
The open cookie button was not visible on an iPhone SE3 if it's in the landscape. After fixing, it now works on any device that is in the landscape.