### PR TITLE
update

### DIFF
--- a/source/fortune-cookie/style.css
+++ b/source/fortune-cookie/style.css
@@ -36,6 +36,7 @@ footer {
   flex-wrap: wrap;
 }
 .voice-select-label {
+  position: relative;
   display: flex;
   gap: 10px;
   justify-content: center;
@@ -329,37 +330,4 @@ aside {
 }
 #cancel-animation-btn:hover {
   text-decoration: underline;
-}
-@media screen and (orientation: landscape) and (max-width: 600px) {
-  footer {
-    margin-bottom: 5px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-  }
-  .fortune-paper {
-    max-width: 90%;
-  }
-  header h1.title {
-    white-space: nowrap;
-    margin: 0;
-  }
-
-  .voice-select-label {
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-    gap: 10px;
-  }
-
-  .voice-select-label select {
-    width: 100%;
-  }
-
-  .button {
-    margin-top: 20px;
-    width: calc(100% - 40px);
-    text-align: center;
-  }
 }


### PR DESCRIPTION
Fix the open cookie button.
The open cookie button was not visible on an iPhone SE3 if it's in the landscape. After fixing, it now works on any device that is in the landscape.